### PR TITLE
Update readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /vendor
 .env
 .env.backup
+.rnd
 .phpunit.result.cache
 Homestead.json
 Homestead.yaml

--- a/database/seeds/PlatformSeeder.php
+++ b/database/seeds/PlatformSeeder.php
@@ -47,6 +47,7 @@ class PlatformSeeder extends Seeder
             'name' => 'Reference Implementation',
             'iss' => 'https://lti-ri.imsglobal.org',
             'auth_req_url' => 'https://lti-ri.imsglobal.org/platforms/643/authorizations/new',
+            'jwks_url' => 'https://lti-ri.imsglobal.org/platforms/643/platform_keys/656.json'
         ]);
         // this is the shim's client_id on the RI platform
         DB::table('platform_clients')->insert([

--- a/readme.md
+++ b/readme.md
@@ -7,9 +7,9 @@
 #### Initial setup:
 
 ```
-git clone --recurse-submodules -b prototype1 git@github.com:/ubc/lti-shim.git
+git clone --recurse-submodules -b prototype1 https://github.com/ubc/lti-shim.git
 cd lti-shim/
-cp .env-example .env
+cp .env.example .env
 cd laradock-lti-shim/
 docker-compose up -d nginx postgres workspace adminer lti-example-tool
 docker-compose exec -u laradock workspace bash
@@ -46,9 +46,9 @@ Migrations can be rolled back in bulk (`artisan migrate:rollback`) or with the a
 
 The database can be completely blown away and rebuilt from scratch using `artisan migrate:refresh`.
 
-Test data for development use can be seeded using `artisan db:seed`. This can be combined with rebuilding the database from scratch as `artisan migrate:refresh --seed`.
-
 ##### Seeded Data
+
+Test data for development use can be seeded using `artisan db:seed`. This can be combined with rebuilding the database from scratch as `artisan migrate:refresh --seed`.
 
 The current seeded data works with this Reference Implemention platform: https://lti-ri.imsglobal.org/platforms/643
 


### PR DESCRIPTION
- fix git clone url (probably from switching off private)
- fix env example name
- move info on seeding and re-seeding the db into the Seeded Data section

Also fixed a few things related to initial setup
- added jwks_url for `lti-ri.imsglobal.org`
- added `.rnd` to gitignore (I think Laravel added during the compose install)